### PR TITLE
Fixing pad buttons being selectable

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -1,3 +1,6 @@
+d_pad {
+  -moz-user-select: none;
+}
 html, body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
On my Flame, when holding buttons for longer period of time (eg moving up a few tiles), the buttons get selected. Solution would be using -moz-user-select: none; on them
